### PR TITLE
Make query items return iterator[any] rather than items

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ This example queries a container for items with a specific `id`:
 database = client.get_database(test_database_name)
 container = database.get_container(test_container_name)
 
-# Get a list of items from the container
-items = list(container.query_items(query='SELECT * FROM root r WHERE r.id="something"'))
+# Get a list of results from the container
+items = container.query_items(query='SELECT * FROM root r WHERE r.id="something"')
 
 # Enumerate the returned items
 import json

--- a/azure/cosmos/__init__.py
+++ b/azure/cosmos/__init__.py
@@ -6,12 +6,13 @@ __all__ = ["CosmosClient", "Database", "Container", "Item"]
 
 
 from internal.cosmos.errors import HTTPFailure
-from .query_iterator import QueryResultIteratable
+from .query_iterator import QueryResultIterator
 
 from typing import (
     Any,
     List,
     Iterable,
+    Iterator,
     Optional,
     Dict,
     Union,
@@ -460,12 +461,12 @@ class Container:
         parameters: "Optional[List]" = None,
         options=None,
         partition_key: "Optional[str]" = None,
-    ) -> "Iterable[Any]":
+    ) -> "Iterator[Any]":
         """Return all results matching the given `query`.
 
         :param query: The Azure Cosmos DB SQL query to execute.
         :param parameters: Optional array of parameters.
-        :returns: An `Iterable` containing each :class:`Item` returned by the query, if any.
+        :returns: An `Iterator` containing each result returned by the query, if any.
 
         **Example:** Find all families in the state of NY.
 
@@ -496,8 +497,8 @@ class Container:
             partition_key=partition_key,
         )
         headers = self.client_context.last_response_headers
-        items_iteratable = iter(items)
-        return QueryResultIteratable(items_iteratable, headers=headers)
+        items_iterator = iter(items)
+        return QueryResultIterator(items_iterator, headers=headers)
 
     def replace_item(self, item: "Union[Item, str]", body: "Dict[str, Any]") -> "Item":
         """ Replaces the specified item if it exists in the container.

--- a/azure/cosmos/__init__.py
+++ b/azure/cosmos/__init__.py
@@ -6,6 +6,7 @@ __all__ = ["CosmosClient", "Database", "Container", "Item"]
 
 
 from internal.cosmos.errors import HTTPFailure
+from .query_iterator import QueryResultIteratable
 
 from typing import (
     Any,
@@ -459,8 +460,8 @@ class Container:
         parameters: "Optional[List]" = None,
         options=None,
         partition_key: "Optional[str]" = None,
-    ) -> "Iterable[Item]":
-        """Return all items matching the given `query`.
+    ) -> "Iterable[Any]":
+        """Return all results matching the given `query`.
 
         :param query: The Azure Cosmos DB SQL query to execute.
         :param parameters: Optional array of parameters.
@@ -495,7 +496,8 @@ class Container:
             partition_key=partition_key,
         )
         headers = self.client_context.last_response_headers
-        yield from [Item(headers, item) for item in items]
+        items_iteratable = iter(items)
+        return QueryResultIteratable(items_iteratable, headers=headers)
 
     def replace_item(self, item: "Union[Item, str]", body: "Dict[str, Any]") -> "Item":
         """ Replaces the specified item if it exists in the container.

--- a/azure/cosmos/__init__.py
+++ b/azure/cosmos/__init__.py
@@ -40,7 +40,7 @@ class User:
 class PartitionKey(dict):
     """ Key used to partition a container into logical partitions.
 
-    See https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview#choose-partitionkey for more information
+    See https://docs.microsoft.com/azure/cosmos-db/partitioning-overview#choose-partitionkey for more information
     on how to choose partition keys.
 
     :ivar path: The path of the partition key

--- a/azure/cosmos/__init__.py
+++ b/azure/cosmos/__init__.py
@@ -22,6 +22,8 @@ from typing import (
     Sequence,
 )
 
+DatabaseId = Union["Database", Dict[str, Any], str]
+ContainerId = Union["Container", Dict[str, Any], str]
 
 from internal.cosmos.cosmos_client import CosmosClient as _CosmosClient
 from internal.cosmos.errors import HTTPFailure
@@ -32,6 +34,45 @@ class ClientContext(_CosmosClient):
 
 
 class User:
+    pass
+
+
+class PartitionKey(dict):
+    """ Key used to partition a container into logical partitions.
+
+    See https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview#choose-partitionkey for more information
+    on how to choose partition keys.
+
+    :ivar path: The path of the partition key
+    :ivar kind: What kind of partition key is being defined
+    """
+
+    def __init__(self, path: "str", kind: "str" = "Hash"):
+        self.path = path
+        self.kind = kind
+
+    @property
+    def kind(self):
+        return self["kind"]
+
+    @kind.setter
+    def kind(self, value):
+        self["kind"] = value
+
+    @property
+    def path(self) -> "str":
+        return self["paths"][0]
+
+    @path.setter
+    def path(self, value: "str"):
+        self["paths"] = [value]
+
+
+class AccessCondition(dict):
+    pass
+
+
+class ResponseMetadata(dict):
     pass
 
 
@@ -68,14 +109,38 @@ class CosmosClient:
         )
 
     @staticmethod
-    def _get_database_link(database_or_id: "Union[str, Database]") -> "str":
-        return getattr(database_or_id, "database_link", f"dbs/{database_or_id}")
+    def _get_database_link(database_or_id: DatabaseId) -> "str":
+        if isinstance(database_or_id, str):
+            return f"dbs/{database_or_id}"
+        try:
+            return cast("Database", database_or_id).database_link
+        except AttributeError:
+            pass
 
-    def create_database(self, id: "str", fail_if_exists: "bool" = False) -> "Database":
-        """ Create a new database with the given ID (name).
+        if isinstance(database_or_id, str):
+            database_id = database_or_id
+        else:
+            database_id = cast("Dict[str, str]", database_or_id)["id"]
+        return f"dbs/{database_id}"
+
+    def create_database(
+        self,
+        id: "str",
+        *,
+        consistency_level=None,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Database":
+        """Create a new database with the given ID (name).
 
         :param id: ID (name) of the database to create.
-        :param fail_if_exists: Fail if database already exists.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :returns: A :class:`Database` instance representing the new database.
         :raises `HTTPFailure`: If `fail_if_exists` is set to True and a database with the given ID already exists.
 
@@ -90,51 +155,181 @@ class CosmosClient:
             database = client.create_database('nameofdatabase')
 
         """
-        try:
-            result = self.client_context.CreateDatabase(database=dict(id=id))
-            return Database(self.client_context, id=result["id"], properties=result)
-        except HTTPFailure as e:
-            if fail_if_exists and e.status_code == 409:
-                raise
-        return self.get_database(id)
+        result = self.client_context.CreateDatabase(database=dict(id=id))
+        return Database(self.client_context, id=result["id"], properties=result)
 
-    def get_database(self, database: "Union[str, Database]") -> "Database":
+    def get_database(
+        self,
+        database: DatabaseId,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Database":
         """
         Retrieve an existing database with the ID (name) `id`.
 
         :param id: ID of the new :class:`Database`.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :raise `HTTPFailure`: If the given database couldn't be retrieved.
         """
         database_link = CosmosClient._get_database_link(database)
-        properties = self.client_context.ReadDatabase(database_link)
-        return Database(self.client_context, properties["id"], properties)
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
 
-    def list_databases(self, query: "Optional[str]" = None) -> "Iterable[Database]":
+        properties = self.client_context.ReadDatabase(
+            database_link, options=request_options
+        )
+        return Database(
+            self.client_context,
+            properties["id"],
+            properties=properties,
+            response_metadata=ResponseMetadata(
+                self.client_context.last_response_headers
+            ),
+        )
+
+    def list_databases(
+        self,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        enable_cross_partition_query: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        max_item_count: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Iterable[Database]":
         """
         List the databases in a Cosmos DB SQL database account.
 
-        :param query: Cosmos DB SQL query. If omitted, all databases in the account are listed.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param max_item_count: Max number of items to be returned in the enumeration operation.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         """
-        if query:
-            yield from [
-                Database(self.client_context, properties["id"], properties)
-                for properties in self.client_context.QueryDatabases(query)
-            ]
-        else:
-            yield from [
-                Database(self.client_context, properties["id"], properties)
-                for properties in self.client_context.ReadDatabases()
-            ]
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if enable_cross_partition_query is not None:
+            request_options["enableCrossPartitionQuery"] = enable_cross_partition_query
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if max_item_count is not None:
+            request_options["maxItemCount"] = max_item_count
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
 
-    def delete_database(self, database: "Union[Database, str]"):
+        yield from [
+            Database(self.client_context, properties["id"], properties=properties)
+            for properties in self.client_context.ReadDatabases(options=request_options)
+        ]
+
+    def list_database_properties(
+        self,
+        query: "Optional[str]" = None,
+        parameters: "Optional[str]" = None,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        enable_cross_partition_query: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        max_item_count: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Iterable[Union[Dict, Any], Any]":
+
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if enable_cross_partition_query is not None:
+            request_options["enableCrossPartitionQuery"] = enable_cross_partition_query
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if max_item_count is not None:
+            request_options["maxItemCount"] = max_item_count
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        if query:
+            # This is currently eagerly evaluated in order to capture the headers
+            # from the call.
+            # (just returning a generator did not initiate the first network call, so
+            # the headers were misleading)
+            # This needs to change for "real" implementation
+            results = iter(
+                list(self.client_context.QueryDatabases(query, options=request_options))
+            )
+        else:
+            results = iter(
+                list(self.client_context.ReadDatabases(options=request_options))
+            )
+        self.session_token = self.client_context.last_response_headers.get(
+            "x-ms-session-token"
+        )
+        return QueryResultIterator(
+            results,
+            metadata=ResponseMetadata(self.client_context.last_response_headers),
+        )
+
+    def delete_database(
+        self,
+        database: DatabaseId,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ):
         """
         Delete the database with the given ID (name).
 
         :param database: The ID (name) or :class:`Database` instance of the database to delete.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :raise HTTPFailure: If the database couldn't be deleted.
         """
+
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
         database_link = CosmosClient._get_database_link(database)
-        self.client_context.DeleteDatabase(database_link)
+        self.client_context.DeleteDatabase(database_link, options=request_options)
 
 
 class Database:
@@ -163,7 +358,9 @@ class Database:
         self,
         client_context: "ClientContext",
         id: "str",
+        *,
         properties: "Optional[Dict[str, Any]]" = None,
+        response_metadata: "Optional[ResponseMetadata]" = None,
     ):
         """
         :param ClientSession client_context: Client from which this database was retrieved.
@@ -172,23 +369,31 @@ class Database:
         self.client_context = client_context
         self.id = id
         self.properties = properties
+        self.response_metadata = response_metadata
         self.database_link = CosmosClient._get_database_link(id)
 
-    def _get_container_link(self, container_or_id: "Union[str, Container]") -> "str":
-        return getattr(
-            container_or_id,
-            "collection_link",
-            f"{self.database_link}/colls/{container_or_id}",
-        )
+    def _get_container_link(self, container_or_id: ContainerId) -> "str":
+        if isinstance(container_or_id, str):
+            return f"{self.database_link}/colls/{container_or_id}"
+        try:
+            return cast("Container", container_or_id).collection_link
+        except AttributeError:
+            pass
+        container_id = cast("Dict[str, str]", container_or_id)["id"]
+        return f"{self.database_link}/colls/{container_id}"
 
     def create_container(
         self,
-        id,
-        options=None,
+        id: str,
         *,
-        partition_key: "Optional[Dict[str, Sequence[str]]]" = None,
+        partition_key: "Optional[PartitionKey]" = None,
         indexing_policy: "Optional[Dict[str, Any]]" = None,
         default_ttl: "int" = None,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
     ) -> "Container":
         """
         Create a new container with the given ID (name).
@@ -199,6 +404,11 @@ class Database:
         :param partition_key: The partition key to use for the container.
         :param indexing_policy: The indexing policy to apply to the container.
         :param default_ttl: Default TTL (time to live) for the container.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
+
         :raise HTTPFailure: The container creation failed.
 
         **Example:** Create a container name 'mycontainer' with default settings:
@@ -213,16 +423,11 @@ class Database:
 
             container = database.create_container(
                 id='containerwithspecificsettings',
-                partition_key={
-                    "paths": [
-                    "/AccountNumber"
-                    ],
-                    "kind": "Hash"
-                }
+                partition_key=PartitionKey(path='/AccountNumber')
             )
 
         """
-        definition = dict(id=id)
+        definition: "Dict[str, Any]" = dict(id=id)
         if partition_key:
             definition["partitionKey"] = partition_key
         if indexing_policy:
@@ -230,32 +435,79 @@ class Database:
         if default_ttl:
             definition["defaultTtl"] = default_ttl
 
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
         data = self.client_context.CreateContainer(
-            database_link=self.database_link, collection=definition, options=options
+            database_link=self.database_link,
+            collection=definition,
+            options=request_options,
         )
         return Container(self.client_context, self, data["id"], properties=data)
 
-    @overload
-    def delete_container(self, container: "str"):
-        ...
-
-    @overload
-    def delete_container(self, container: "Container"):
-        ...
-
-    def delete_container(self, container: "Union[str, Container]"):
+    def delete_container(
+        self,
+        container: ContainerId,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ):
         """ Delete the container
 
         :param container: The ID (name) of the container to delete. You can either pass in the ID of the container to delete, or :class:`Container` instance.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         """
-        collection_link = self._get_container_link(container)
-        self.client_context.DeleteContainer(collection_link)
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
 
-    def get_container(self, container: "Union[str, Container]") -> "Container":
+        collection_link = self._get_container_link(container)
+        self.client_context.DeleteContainer(collection_link, options=request_options)
+
+    def get_container(
+        self,
+        container: ContainerId,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Container":
         """ Get the container with the ID (name) `container`.
 
         :param container: The ID (name) of the container, or a :class:`Container` instance.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :raise `HTTPFailure`: Raised if the container couldn't be retrieved. This includes if the container does not exist.
+        :returns: :class:`Container`, if present in the container.
 
         .. code-block:: python
 
@@ -268,10 +520,20 @@ class Database:
                 else:
                     print(f'Failed to retrieve container. Status code:{failure.status_code}')
         """
-        collection_link = getattr(
-            container, "collection_link", f"{self.database_link}/colls/{container}"
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        collection_link = self._get_container_link(container)
+        container_properties = self.client_context.ReadContainer(
+            collection_link, options=request_options
         )
-        container_properties = self.client_context.ReadContainer(collection_link)
         return Container(
             self.client_context,
             self,
@@ -280,12 +542,22 @@ class Database:
         )
 
     def list_containers(
-        self, query: "str" = None, parameters=None
+        self,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        max_item_count: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
     ) -> "Iterable[Container]":
         """ List the containers in this database.
 
-        :param query: The SQL query used for filtering the list of containers. If omitted, all containers in the database are returned.
-        :param parameters: Parameters for the query. Only applicable if a query has been specified.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param max_item_count: Max number of items to be returned in the enumeration operation.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
 
         **Example**: List all containers in a database.
 
@@ -294,36 +566,109 @@ class Database:
             database.list_containers()
 
         """
-        if query:
-            yield from [
-                Container(self.client_context, self, container["id"], container)
-                for container in self.client_context.QueryContainers(
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if max_item_count is not None:
+            request_options["maxItemCount"] = max_item_count
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        yield from [
+            Container(self.client_context, self, container["id"], container)
+            for container in self.client_context.ReadContainers(
+                database_link=self.database_link, options=request_options
+            )
+        ]
+
+    def list_container_properties(
+        self,
+        *,
+        query: "str" = None,
+        parameters: "str" = None,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        max_item_count: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ):
+        """List properties for containers in the current database
+
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param max_item_count: Max number of items to be returned in the enumeration operation.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
+
+    """
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        result = iter(
+            list(
+                self.client_context.QueryContainers(
                     database_link=self.database_link,
                     query=query
                     if parameters is None
                     else dict(query=query, parameters=parameters),
+                    options=request_options,
                 )
-            ]
-        else:
-            yield from [
-                Container(self.client_context, self, container["id"], container)
-                for container in self.client_context.ReadContainers(
-                    database_link=self.database_link
-                )
-            ]
+            )
+        )
+
+        return QueryResultIterator(
+            result, metadata=ResponseMetadata(self.client_context.last_response_headers)
+        )
 
     def set_container_properties(
         self,
         container: "Union[str, Container]",
         *,
-        partition_key=None,
+        partition_key: "Optional[PartitionKey]" = None,
         indexing_policy=None,
         default_ttl=None,
         conflict_resolution_policy=None,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
     ):
         """ Update the properties of the container. Property changes are persisted immediately.
+
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         """
         container_id = getattr(container, "id", container)
+
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
         parameters = {
             key: value
             for key, value in {
@@ -333,11 +678,12 @@ class Database:
                 "defaultTtl": int(default_ttl),
                 "conflictResolutionPolicy": conflict_resolution_policy,
             }.items()
-            if value
-            is not None  # TODO: Questionable use - should use kwargs instead. Need to figure out best documentation for kwargs...
+            if value is not None
         }
         collection_link = f"{self.database_link}/colls/{container_id}"
-        self.client_context.ReplaceContainer(collection_link, collection=parameters)
+        self.client_context.ReplaceContainer(
+            collection_link, collection=parameters, options=request_options
+        )
 
     def get_user_link(self, id_or_user: "Union[User, str]") -> "str":
         user_link = getattr(
@@ -370,17 +716,20 @@ class Database:
         database = cast("Database", self)
         return database.client_context.ReadUser(self.get_user_link(id))
 
-    def list_users(self, query=None):
+    def list_users(self):
         """ Get all database users.
         """
         database = cast("Database", self)
-        yield from [User(user) for user in database.client_context.ReadUsers(query)]
+        yield from [User(user) for user in database.client_context.ReadUsers()]
+
+    def list_user_properties(self, query: "str" = None, parameters=None):
+        pass
 
     def delete_user(self, user):
         """ Delete the specified user from the database.
         """
         database = cast("Database", self)
-        database.client_context.DeleteUser(self.get_user_link(id))
+        database.client_context.DeleteUser(self.get_user_link(user))
 
 
 class Item(dict):
@@ -388,6 +737,7 @@ class Item(dict):
 
     To create, read, update, and delete Items, use the associated methods on the :class:`Container`.
     """
+
     def __init__(self, headers: "Dict[str, Any]", data: "Dict[str, Any]"):
         super().__init__()
         self.response_headers = headers
@@ -399,8 +749,8 @@ class Container:
 
     A container in an Azure Cosmos DB SQL API database is a collection of documents, each of which represented as an :class:`Item`.
 
-    :ivar id: ID (name) of the container
-    :session_token: The session token for the container.
+    :ivar str id: ID (name) of the container
+    :ivar str session_token: The session token for the container.
     """
 
     def __init__(
@@ -414,34 +764,95 @@ class Container:
         self.session_token = None
         self.id = id
         self.properties = properties
-        database_link = getattr(database, "database_link", f"dbs/{database}")
+        database_link = CosmosClient._get_database_link(database)
         self.collection_link = f"{database_link}/colls/{self.id}"
 
-    @staticmethod
-    def _document_link(item_or_link) -> "str":
+    def _get_document_link(
+        self, item_or_link: "Union[str, Dict[str, Any], Item]"
+    ) -> "str":
         if isinstance(item_or_link, str):
-            return item_or_link
+            return f"{self.collection_link}/docs/{item_or_link}"
         return cast("str", cast("Item", item_or_link)["_self"])
 
-    def get_item(self, id: "str") -> "Item":
+    def get_item(
+        self,
+        id: "str",
+        *,
+        partition_key: "Optional[str]" = None,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Item":
         """
         Get the item identified by `id`.
 
-        :param str id: ID of item to retrieve.
+        :param id: ID of item to retrieve.
+        :param partition_key: Partition key for the item to retrieve.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :returns: :class:`Item`, if present in the container.
         """
-        doc_link = f"{self.collection_link}/docs/{id}"
-        result = self.client_context.ReadItem(document_link=doc_link)
+        doc_link = self._get_document_link(id)
+
+        request_options: "Dict[str, Any]" = {}
+        if partition_key:
+            request_options["partitionKey"] = partition_key
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        result = self.client_context.ReadItem(
+            document_link=doc_link, options=request_options
+        )
         headers = self.client_context.last_response_headers
         self.session_token = headers.get("x-ms-session-token", self.session_token)
         return Item(headers=headers, data=result)
 
-    def list_items(self, options=None) -> "Iterable[Item]":
+    def list_items(
+        self,
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        enable_cross_partition_query: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        max_item_count: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Iterable[Item]":
         """ List all items in the container.
+
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param enable_cross_partition_query: Allow scan on the queries which couldn't be served as indexing was opted out on the requested paths.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param max_item_count: Max number of items to be returned in the enumeration operation.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         """
-        options = options or {}
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if enable_cross_partition_query is not None:
+            request_options["enableCrossPartitionQuery"] = enable_cross_partition_query
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if max_item_count is not None:
+            request_options["maxItemCount"] = max_item_count
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
         items = self.client_context.ReadItems(
-            collection_link=self.collection_link, feed_options=options
+            collection_link=self.collection_link, feed_options=request_options
         )
         headers = self.client_context.last_response_headers
         yield from [Item(headers=headers, data=item) for item in items]
@@ -459,13 +870,27 @@ class Container:
         self,
         query: "str",
         parameters: "Optional[List]" = None,
-        options=None,
+        *,
         partition_key: "Optional[str]" = None,
-    ) -> "Iterator[Any]":
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        enable_cross_partition_query: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        max_item_count: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "QueryResultIterator":
         """Return all results matching the given `query`.
 
         :param query: The Azure Cosmos DB SQL query to execute.
-        :param parameters: Optional array of parameters.
+        :param parameters: Optional array of parameters to the query. Ignored if no query is provided.
+        :param partition_key: Specifies the partition key value for the item.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param enable_cross_partition_query: Allow scan on the queries which couldn't be served as indexing was opted out on the requested paths.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param max_item_count: Max number of items to be returned in the enumeration operation.
+        :param session_token: Token for use with Session consistency.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :returns: An `Iterator` containing each result returned by the query, if any.
 
         **Example:** Find all families in the state of NY.
@@ -488,68 +913,199 @@ class Container:
             )
 
         """
+        request_options: "Dict[str, Any]" = {}
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if enable_cross_partition_query is not None:
+            request_options["enableCrossPartitionQuery"] = enable_cross_partition_query
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if max_item_count is not None:
+            request_options["maxItemCount"] = max_item_count
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
         items = self.client_context.QueryItems(
             database_or_Container_link=self.collection_link,
             query=query
             if parameters is None
             else dict(query=query, parameters=parameters),
-            options=options,
+            options=request_options,
             partition_key=partition_key,
         )
         headers = self.client_context.last_response_headers
+        self.session_token = headers["x-ms-session-token"]
         items_iterator = iter(items)
-        return QueryResultIterator(items_iterator, headers=headers)
+        return QueryResultIterator(items_iterator, metadata=ResponseMetadata(headers))
 
-    def replace_item(self, item: "Union[Item, str]", body: "Dict[str, Any]") -> "Item":
+    def replace_item(
+        self,
+        item: "Union[Item, str]",
+        body: "Dict[str, Any]",
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Item":
         """ Replaces the specified item if it exists in the container.
 
         :param body: A dict-like object or string representing the item to replace.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :raises `HTTPFailure`:
         """
-        item_link = Container._document_link(item)
+        item_link = self._get_document_link(item)
+        request_options: "Dict[str, Any]" = {}
+        request_options["disableIdGeneration"] = True
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
         data = self.client_context.ReplaceItem(
-            document_link=item_link, new_document=body
+            document_link=item_link, new_document=body, options=request_options
         )
         return Item(headers=self.client_context.last_response_headers, data=data)
 
-    def upsert_item(self, body: "Dict[str, Any]") -> "Item":
+    def upsert_item(
+        self,
+        body: "Dict[str, Any]",
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Item":
         """ Insert or update the specified item.
 
         :param body: A dict-like object or string representing the item to update or insert.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :raises `HTTPFailure`:
 
         If the item already exists in the container, it is replaced. If it does not, it is inserted.
         """
+        request_options: "Dict[str, Any]" = {}
+        request_options["disableIdGeneration"] = True
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
 
         result = self.client_context.UpsertItem(
             database_or_Container_link=self.collection_link, document=body
         )
         return Item(headers=self.client_context.last_response_headers, data=result)
 
-    def create_item(self, body: "Dict[str, Any]") -> "Item":
+    def create_item(
+        self,
+        body: "Dict[str, Any]",
+        *,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "Item":
         """ Create an item in the container.
 
         :param body: A dict-like object or string representing the item to create.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :returns: The :class:`Item` inserted into the container.
         :raises `HTTPFailure`:
 
         To update or replace an existing item, use the :func:`Container.upsert_item` method.
 
         """
+        request_options: "Dict[str, Any]" = {}
+        request_options["disableIdGeneration"] = True
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
         result = self.client_context.CreateItem(
-            database_or_Container_link=self.collection_link, document=body
+            database_or_Container_link=self.collection_link,
+            document=body,
+            options=request_options,
         )
         return Item(headers=self.client_context.last_response_headers, data=result)
 
-    def delete_item(self, item: "Item") -> "None":
+    def delete_item(
+        self,
+        item: "Union[Item, Dict[str, Any], str]",
+        *,
+        partition_key: "Optional[str]" = None,
+        disable_ru_per_minute_usage: "Optional[bool]" = None,
+        max_degree_parallelism: "Optional[int]" = None,
+        session_token: "Optional[str]" = None,
+        initial_headers: "Optional[Dict[str, Any]]" = None,
+        access_condition: "Optional[AccessCondition]" = None,
+        populate_query_metrics: "Optional[bool]" = None,
+    ) -> "None":
         """ Delete the specified item from the container.
 
         :param item: The :class:`Item` to delete from the container.
+        :param partition_key: Specifies the partition key value for the item.
+        :param disable_ru_per_minute_usage: Enable/disable Request Units(RUs)/minute capacity to serve the request if regular provisioned RUs/second is exhausted.
+        :param max_degree_parallelism: The maximum number of concurrent operations that run client side during parallel query execution in the Azure Cosmos DB database service. Negative values make the system automatically decides the number of concurrent operations to run.
+        :param session_token: Token for use with Session consistency.
+        :param access_condition: Conditions Associated with the request.
+        :param populate_query_metrics: Enable returning query metrics in response headers.
         :raises `HTTPFailure`: The item wasn't deleted successfully. If the item does not exist in the container, a `404` error is returned.
 
         """
-        document_link = Container._document_link(item)
-        self.client_context.DeleteItem(document_link=document_link)
+        request_options: "Dict[str, Any]" = {}
+        if partition_key:
+            request_options["partitionKey"] = partition_key
+        if disable_ru_per_minute_usage is not None:
+            request_options["disableRUPerMinuteUsage"] = disable_ru_per_minute_usage
+        if max_degree_parallelism is not None:
+            request_options["maxDegreeOfParallelism"] = max_degree_parallelism
+        if session_token:
+            request_options["sessionToken"] = session_token
+        if initial_headers:
+            request_options["initialHeaders"] = initial_headers
+        if access_condition:
+            request_options["accessCondition"] = access_condition
+        if populate_query_metrics is not None:
+            request_options["populateQueryMetrics"] = populate_query_metrics
+
+        document_link = self._get_document_link(item)
+        self.client_context.DeleteItem(
+            document_link=document_link, options=request_options or None
+        )
 
     def list_stored_procedures(self, query):
         pass

--- a/azure/cosmos/query_iterator.py
+++ b/azure/cosmos/query_iterator.py
@@ -9,8 +9,8 @@ class QueryResultIterator(collections.abc.Iterator):
     functions, or it may be a dictionary for projections.
     """
 
-    def __init__(self, inner, headers=None):
-        self.headers = headers
+    def __init__(self, inner, metadata=None):
+        self.response_metadata = metadata
         self._inner = inner
 
     def __next__(self):

--- a/azure/cosmos/query_iterator.py
+++ b/azure/cosmos/query_iterator.py
@@ -1,0 +1,19 @@
+import collections.abc
+
+
+class QueryResultIteratable(collections.abc.Iterator):
+    """ Iterator over query results from Azure Cosmos SQL DB
+
+    The type of each item returned by the iterator depends on the specific
+    query used to generate the result set. It may be a scalar value for aggregate
+    functions, or it may be a dictionary for projections.
+    """
+    def __init__(self, inner, headers=None):
+        self.headers = headers
+        self._inner = inner
+
+    def __next__(self):
+        return self._inner.__next__()
+
+    def __iter__(self):
+        return self

--- a/azure/cosmos/query_iterator.py
+++ b/azure/cosmos/query_iterator.py
@@ -1,13 +1,14 @@
 import collections.abc
 
 
-class QueryResultIteratable(collections.abc.Iterator):
+class QueryResultIterator(collections.abc.Iterator):
     """ Iterator over query results from Azure Cosmos SQL DB
 
     The type of each item returned by the iterator depends on the specific
     query used to generate the result set. It may be a scalar value for aggregate
     functions, or it may be a dictionary for projections.
     """
+
     def __init__(self, inner, headers=None):
         self.headers = headers
         self._inner = inner

--- a/examples/databasemanagementsample.py
+++ b/examples/databasemanagementsample.py
@@ -21,7 +21,7 @@ class DatabaseManagement:
     def create_database(client, id):
         print("2. Create database")
         try:
-            database = client.create_database(id, fail_if_exists=True)
+            database = client.create_database(id)
             print(f"A database with id {database.id} created")
         except HTTPFailure as e:
             if e.status_code == 409:

--- a/examples/databasemanagementsample.py
+++ b/examples/databasemanagementsample.py
@@ -2,8 +2,8 @@ import os
 
 from azure.cosmos import CosmosClient, HTTPFailure
 
-AUTH_URI = os.environ.get("ACCOUNT_URI")
-AUTH_KEY = os.environ.get("ACCOUNT_KEY")
+AUTH_URI = os.environ["ACCOUNT_URI"]
+AUTH_KEY = os.environ["ACCOUNT_KEY"]
 TEST_DB_NAME = "testdatabasemanagementdb"
 
 
@@ -11,17 +11,10 @@ class DatabaseManagement:
     @staticmethod
     def find_database(client, id):
         print("1. Query for database")
-        databases = list(
-            client.list_databases(
-                query=dict(
-                    query="SELECT * FROM r WHERE r.id=@id",
-                    parameters=[dict(name="@id", value=id)],
-                )
-            )
-        )
-        if databases:
-            print(f"Database with id {id} was found")
-        else:
+        try:
+            database = client.get_database(id)
+            print(f"Database with id {database.id} was found")
+        except HTTPFailure:
             print(f"Database with id {id} was not found")
 
     @staticmethod
@@ -29,7 +22,7 @@ class DatabaseManagement:
         print("2. Create database")
         try:
             database = client.create_database(id, fail_if_exists=True)
-            print(f"A database with id {id} created")
+            print(f"A database with id {database.id} created")
         except HTTPFailure as e:
             if e.status_code == 409:
                 print(f"A database with id {id} already exists")

--- a/examples/documentmanagementsample.py
+++ b/examples/documentmanagementsample.py
@@ -1,7 +1,7 @@
 import os
 import datetime
 
-from azure.cosmos import CosmosClient, HTTPFailure
+from azure.cosmos import CosmosClient, HTTPFailure, PartitionKey
 
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites -
@@ -25,11 +25,11 @@ from azure.cosmos import CosmosClient, HTTPFailure
 # 5. Delete a Database given its Id property (DeleteDatabase)
 # ----------------------------------------------------------------------------------------------------------
 
-class DocumentManagement:
 
+class DocumentManagement:
     @staticmethod
     def create_documents(container):
-        print('Creating Documents')
+        print("Creating Documents")
 
         # Create a SalesOrder object. This object has nested properties and various types including numbers, DateTimes and strings.
         # This can be saved as JSON as-is, without converting into rows/columns.
@@ -38,7 +38,7 @@ class DocumentManagement:
             container.create_item(sales_order)
         except HTTPFailure as e:
             if e.status_code == 409:
-                print('Document with id "{}" already exists'.format(sales_order['id']))
+                print('Document with id "{}" already exists'.format(sales_order["id"]))
         # As your app evolves, let's say your object has a new schema. You can insert SalesOrderV2 objects without any
         # changes to the database tier.
         sales_order2 = DocumentManagement.GetSalesOrderV2("SalesOrder2")
@@ -46,111 +46,117 @@ class DocumentManagement:
             container.create_item(sales_order2)
         except HTTPFailure as e:
             if e.status_code == 409:
-                print('Document with id {} already exists'.format(sales_order['id']))
+                print("Document with id {} already exists".format(sales_order["id"]))
 
     @staticmethod
     def read_document(container, id):
-        print('\n1.2 Reading Document by Id\n')
+        print("\n1.2 Reading Document by Id\n")
 
         # Note that Reads require a partition key to be specified. This can be skipped if your collection is not
         # partitioned i.e. does not have a partition key definition during creation.
-        response = container.get_item(id)
+        response = container.get_item(id, partition_key="PO18009186470")
 
-        print('Document read by Id {0}'.format(id))
-        print('Account Number: {0}'.format(response.get('account_number')))
+        print("Document read by Id {0}".format(id))
+        print("Account Number: {0}".format(response.get("account_number")))
 
     @staticmethod
     def read_documents(container):
-        print('\n1.3 - Reading all documents in a container\n')
+        print("\n1.3 - Reading all documents in a container\n")
 
         # NOTE: Use MaxItemCount on Options to control how many documents come back per trip from the server.
         #       It's important to handle throttling whenever you are doing operations such as this that might
         #       result in a 429 (throttled request).
-        documentlist = list(container.list_items(options={'maxItemCount':10}))
+        documentlist = list(container.list_items(max_item_count=1))
 
-        print('Found {0} documents'.format(len(documentlist)))
+        print("Found {0} documents".format(len(documentlist)))
 
         for doc in documentlist:
-            print('Document Id: {0}'.format(doc.get('id')))
+            print("Document Id: {0}".format(doc.get("id")))
 
     @staticmethod
     def GetSalesOrder(document_id):
-        order1 = {'id' : document_id,
-                'account_number' : 'Account1',
-                'purchase_order_number' : 'PO18009186470',
-                'order_date' : datetime.date(2005,1,10).strftime('%c'),
-                'subtotal' : 419.4589,
-                'tax_amount' : 12.5838,
-                'freight' : 472.3108,
-                'total_due' : 985.018,
-                'items' : [
-                    {'order_qty' : 1,
-                     'product_id' : 100,
-                     'unit_price' : 418.4589,
-                     'line_price' : 418.4589
-                    }
-                    ],
-                'ttl' : 60 * 60 * 24 * 30
+        order1 = {
+            "id": document_id,
+            "account_number": "Account1",
+            "purchase_order_number": "PO18009186470",
+            "order_date": datetime.date(2005, 1, 10).strftime("%c"),
+            "subtotal": 419.4589,
+            "tax_amount": 12.5838,
+            "freight": 472.3108,
+            "total_due": 985.018,
+            "items": [
+                {
+                    "order_qty": 1,
+                    "product_id": 100,
+                    "unit_price": 418.4589,
+                    "line_price": 418.4589,
                 }
+            ],
+            "ttl": 60 * 60 * 24 * 30,
+        }
 
         return order1
 
     @staticmethod
     def GetSalesOrderV2(document_id):
         # Notice new fields have been added to the sales order
-        order2 = {'id' : document_id,
-                'account_number' : 'Account2',
-                'purchase_order_number' : 'PO15428132599',
-                'order_date' : datetime.date(2005,7,11).strftime('%c'),
-                'due_date' : datetime.date(2005,7,21).strftime('%c'),
-                'shipped_date' : datetime.date(2005,7,15).strftime('%c'),
-                'subtotal' : 6107.0820,
-                'tax_amount' : 586.1203,
-                'freight' : 183.1626,
-                'discount_amt' : 1982.872,
-                'total_due' : 4893.3929,
-                'items' : [
-                    {'order_qty' : 3,
-                     'product_code' : 'A-123',      # Notice how in item details we no longer reference a ProductId.
-                     'product_name' : 'Product 1',  # Instead, we've decided to de-normalize our schema and include
-                     'currency_symbol' : '$',       # the Product details relevant to the Order on the Order directly.
-                     'currency_code' : 'USD',       # This is a typical refactor that happens in the course of an application
-                     'unit_price' : 17.1,           # that would have previously required schema changes, data migrations, etc.
-                     'line_price' : 5.7
-                    }
-                    ],
-                'ttl' : 60 * 60 * 24 * 30
+        order2 = {
+            "id": document_id,
+            "account_number": "Account2",
+            "purchase_order_number": "PO15428132599",
+            "order_date": datetime.date(2005, 7, 11).strftime("%c"),
+            "due_date": datetime.date(2005, 7, 21).strftime("%c"),
+            "shipped_date": datetime.date(2005, 7, 15).strftime("%c"),
+            "subtotal": 6107.0820,
+            "tax_amount": 586.1203,
+            "freight": 183.1626,
+            "discount_amt": 1982.872,
+            "total_due": 4893.3929,
+            "items": [
+                {
+                    "order_qty": 3,
+                    "product_code": "A-123",  # Notice how in item details we no longer reference a ProductId.
+                    "product_name": "Product 1",  # Instead, we've decided to de-normalize our schema and include
+                    "currency_symbol": "$",  # the Product details relevant to the Order on the Order directly.
+                    "currency_code": "USD",  # This is a typical refactor that happens in the course of an application
+                    "unit_price": 17.1,  # that would have previously required schema changes, data migrations, etc.
+                    "line_price": 5.7,
                 }
+            ],
+            "ttl": 60 * 60 * 24 * 30,
+        }
 
         return order2
-
 
 
 def run_sample():
     AUTH_URI = os.environ.get("ACCOUNT_URI")
     AUTH_KEY = os.environ.get("ACCOUNT_KEY")
-    DATABASE_ID = 'testdocumentmanagementdb'
-    CONTAINER_ID = 'testdocumentmanagementcollection'
+    DATABASE_ID = "testdocumentmanagementdb"
+    CONTAINER_ID = "testdocumentmanagementcollection"
 
     client = CosmosClient(AUTH_URI, AUTH_KEY)
     database = client.create_database(id=DATABASE_ID)
+    partition_key = PartitionKey(path="/purchase_order_number")
     try:
-        container = database.create_container(id=CONTAINER_ID)
+        container = database.create_container(
+            id=CONTAINER_ID, partition_key=partition_key
+        )
         print(f'Container with id "{CONTAINER_ID}"" created')
     except HTTPFailure as e:
         if e.status_code == 409:
-            print(f'Container with id {CONTAINER_ID} already exists')
+            print(f"Container with id {CONTAINER_ID} already exists")
             container = database.get_container(container=CONTAINER_ID)
         else:
             raise
 
-
     DocumentManagement.create_documents(container)
-    DocumentManagement.read_document(container,'SalesOrder1')
+    DocumentManagement.read_document(container, "SalesOrder1")
     DocumentManagement.read_documents(container)
 
     client.delete_database(database=DATABASE_ID)
     print("\nrun_sample done")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_sample()

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -5,7 +5,7 @@
 
 # All interaction with Cosmos DB starts with an instance of the CosmosClient
 # [START create_client]
-from azure.cosmos import HTTPFailure, CosmosClient, Container, Database
+from azure.cosmos import HTTPFailure, CosmosClient, Container, Database, PartitionKey
 
 import os
 
@@ -44,12 +44,8 @@ customer_container_name = 'customers'
 try:
     customer_container = database.create_container(
         id=customer_container_name,
-        partition_key={
-            "paths": [
-            "/AccountNumber"
-            ],
-            "kind": "Hash"
-        }
+        partition_key=PartitionKey(path="/productName"),
+        default_ttl=200,
     )
 except HTTPFailure as e:
     if e.status_code != 409:

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,16 +1,21 @@
-from azure.cosmos import HTTPFailure, CosmosClient, Container, Database
+from azure.cosmos import HTTPFailure, CosmosClient, Container, PartitionKey
 
 # All interaction with Cosmos DB starts with an instance of the CosmosClient
 import os
-url = os.environ['ACCOUNT_URI']
-key = os.environ['ACCOUNT_KEY']
+
+url = os.environ["ACCOUNT_URI"]
+key = os.environ["ACCOUNT_KEY"]
 client = CosmosClient(url, key)
 
-test_database_name = 'testDatabase'
-test_container_name = 'testContainer'
+test_database_name = "testDatabase"
+test_container_name = "testContainer"
 
 # Create a database
-db = client.create_database(id=test_database_name, fail_if_exists=False)
+try:
+    db = client.create_database(id=test_database_name)
+except HTTPFailure:
+    db = client.get_database(database=test_database_name)
+
 try:
     db.create_container(id=test_container_name)
 except HTTPFailure as e:
@@ -20,26 +25,23 @@ except HTTPFailure as e:
 
 # Retrieve a container by using known database and container names, then
 # insert an item:
-container = Container(client.client_context, database=test_database_name, id=test_container_name)
-container.upsert_item({
-    'id': 'something',
-    'value': 'new'
-})
+container = Container(
+    client.client_context, database=test_database_name, id=test_container_name
+)
+container.upsert_item({"id": "something", "value": "new"})
 
 # Retrieve a container by walking down resource hierarchy (client->databases->containers), then
 # insert an item.
 database = client.get_database(test_database_name)
 container = database.get_container(test_container_name)
-container.upsert_item({
-    'id': 'another',
-    'value': 'something'
-})
+container.upsert_item({"id": "another", "value": "something"})
 
 # With a Container object, you can query items within it:
 items = list(container.query_items(query='SELECT * FROM root r WHERE r.id="something"'))
 
 # Enumerate the items you've retrieved with your query:
 import json
+
 for item in items:
     print(json.dumps(item, indent=True))
 
@@ -49,17 +51,14 @@ for item in items:
 
 # Insert new items by defining a dict and calling Container.upsert_item
 for i in range(1, 10):
-    container.upsert_item(dict(
-        id=f'item{i}',
-        firstName='David',
-        lastName='Smith'
-        )
-    )
+    container.upsert_item(dict(id=f"item{i}", firstName="David", lastName="Smith"))
 
 # Modify an existing item in the container
 item = items[0]
-item['firstName'] = 'Some Other Name'
-updated_item = container.upsert_item(item) # ISSUE: do we update the item "in place" for system properties and  headers?
+item["firstName"] = "Some Other Name"
+updated_item = container.upsert_item(
+    item
+)  # ISSUE: do we update the item "in place" for system properties and  headers?
 
 # Retrieve the properties of a database
 properties = database.properties
@@ -68,8 +67,37 @@ print(json.dumps(properties, indent=True))
 # Modify the properties of an existing container
 # This example sets the default time to live (TTL) for items in the container to 10 seconds
 # An item in container is deleted when the TTL expires since it was last edited
-database.set_container_properties(container, default_ttl=10)
+database.set_container_properties(container, default_ttl=10, indexing_policy={})
 
 # Display the new TTL setting for the container
 container_props = database.get_container(test_container_name).properties
-print(json.dumps(container_props['defaultTtl']))
+print(json.dumps(container_props["defaultTtl"]))
+
+
+# Create a partitioned container and run some queries over it
+try:
+    partitioned_container = database.get_container("partitioned")
+except:
+    partitioned_container = database.create_container(
+        "partitioned", partition_key=PartitionKey("/city")
+    )
+partitioned_container.upsert_item(
+    dict(id="1", name="Someone young", age=47, city="Redmond")
+)
+
+partitioned_container.upsert_item(
+    dict(id="1", name="Someone old", age=96, city="Kirkland")
+)
+
+items = list(partitioned_container.list_items())
+print(items)
+average_age = partitioned_container.query_items(
+    "SELECT VALUE AVG(c.age) FROM c", enable_cross_partition_query=True
+)
+
+print(average_age.response_metadata)
+print(partitioned_container.session_token)
+print(next(average_age))
+
+first_item = partitioned_container.get_item("1", partition_key="Redmond")
+partitioned_container.delete_item(first_item, partition_key="Redmond")

--- a/examples/randomtest.py
+++ b/examples/randomtest.py
@@ -15,12 +15,16 @@ def do_basic_stuff():
             for item in container.list_items():
                 print(item)
 
-database = client.create_database("swaggers", fail_if_exists=False)
+try:
+    database = client.create_database("swaggers")
+except HTTPFailure:
+    database = client.get_database("swaggers")
+
 try:
     container = database.get_container(
         "publicmaster"
     )  # TODO: Why not have a fail_if_exists on every create?
-except ValueError:  # TODO: What is the appropriate exception here?
+except HTTPFailure:  # TODO: What is the appropriate exception here?
     container = database.create_container("publicmaster")
 
 import time
@@ -37,7 +41,7 @@ container = database.create_container(
     id='containerwithspecificsettings',
     partition_key={
         "paths": [
-        "/AccountNumber"
+        "/info/version"
         ],
         "kind": "Hash"
     }
@@ -64,7 +68,7 @@ def upload():
                     pass
 
 def find_stuff(query):
-    items = container.query_items(query)
+    items = container.query_items(query, enable_cross_partition_query=True)
 
     for item in items:
         item = container.get_item(item["id"])


### PR DESCRIPTION
Any projections or aggregate queries may not return an iterator[Item] but rather an iterator of either scalar (for VALUE aggregate queries) or arbitrary documents (for projections).

This change makes this clear and it also squirrels away the metadata/header result of the query onto the iterator rather than on each item returned. 