### PR TITLE
Use literalinclude for code snippets

### DIFF
--- a/azure/cosmos/__init__.py
+++ b/azure/cosmos/__init__.py
@@ -48,7 +48,7 @@ class CosmosClient:
         :param url: The URL of the Cosmos DB account.
         :param consistency_level: Consistency level to use for the session.
 
-        **Example**: Create a new client instance.
+        **Example:** Create a new instance of the Cosmos DB client.
 
         .. literalinclude:: ../../examples/examples.py
             :start-after: [START create_client]
@@ -76,7 +76,7 @@ class CosmosClient:
         :returns: A :class:`Database` instance representing the new database.
         :raises `HTTPFailure`: If `fail_if_exists` is set to True and a database with the given ID already exists.
 
-        **Example**: Create a database in the Cosmos DB account.
+        **Example:** Create a database in the Cosmos DB account.
 
         .. literalinclude:: ../../examples/examples.py
             :start-after: [START create_database]
@@ -138,8 +138,9 @@ class Database:
     A database contains one or more containers, each of which can contain items,
     stored procedures, triggers, and user-defined functions.
 
-    A database also has associated users, each with a set of permissions to access various
-    other containers, stored procedures, triggers, user defined functions, or items
+    A database can also have associated users, each of which configured with
+    a set of permissions for accessing certain containers, stored procedures,
+    triggers, user defined functions, or items.
 
     :ivar id: The ID (name) of the database.
     :ivar properties: A dictionary of system-generated properties for this database. See below for the list of keys.
@@ -147,7 +148,7 @@ class Database:
     An Azure Cosmos DB SQL API database has the following system-generated properties; these properties are read-only:
 
     * `_rid`:   The resource ID.
-    * `_ts`:    Specifies the last updated timestamp of the resource. The value is a timestamp.
+    * `_ts`:    When the resource was last updated. The value is a timestamp.
     * `_self`:	The unique addressable URI for the resource.
     * `_etag`:	The resource etag required for optimistic concurrency control.
     * `_colls`:	The addressable path of the collections resource.
@@ -190,13 +191,13 @@ class Database:
 
         If a container with the given ID already exists, an HTTPFailure with status_code 409 is raised.
 
-        :param id: ID of container to create.
+        :param id: ID (name) of container to create.
         :param partition_key: The partition key to use for the container.
         :param indexing_policy: The indexing policy to apply to the container.
-        :param default_ttl: Default TTL (time to live) for the container.
+        :param default_ttl: Default time to live (TTL) for items in the container. If unspecified, items do not expire.
         :raise HTTPFailure: The container creation failed.
 
-        **Example:** Create a container name 'mycontainer' with default settings:
+        **Example:** Create a container with default settings.
 
         .. literalinclude:: ../../examples/examples.py
             :start-after: [START create_container]
@@ -204,7 +205,7 @@ class Database:
             :language: python
             :dedent: 0
 
-        **Example:** Create a container named 'containerwithspecificsettings' with a custom partition key.
+        **Example:** Create a container with specific settings; in this case, a custom partition key.
 
         .. literalinclude:: ../../examples/examples.py
             :start-after: [START create_container_with_settings]
@@ -274,7 +275,7 @@ class Database:
         :param query: The SQL query used for filtering the list of containers. If omitted, all containers in the database are returned.
         :param parameters: Parameters for the query. Only applicable if a query has been specified.
 
-        **Example**: List all containers in a database.
+        **Example:** List all containers in the database.
 
         .. literalinclude:: ../../examples/examples.py
             :start-after: [START list_containers]
@@ -348,11 +349,13 @@ class Database:
 
         The user ID must be unique within the database, and consist of no more than 255 characters.
 
-        .. code-block:: python
+        **Example:** Create a database user.
 
-            database.create_user(dict(
-                id='Walter Harp'
-                ))
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START create_user]
+            :end-before: [END create_user]
+            :language: python
+            :dedent: 0
 
         """
         database = cast("Database", self)
@@ -426,7 +429,7 @@ class Container:
         :param str id: ID of item to retrieve.
         :returns: :class:`Item`, if present in the container.
 
-        **Example**: Get an item from the database and update one of its properties.
+        **Example:** Get an item from the database and update one of its properties.
 
         .. literalinclude:: ../../examples/examples.py
             :start-after: [START update_item]
@@ -477,24 +480,21 @@ class Container:
         In the examples below, the container name is "products," and is aliased as "p" for easier referencing
         in the WHERE clause.
 
-        **Example:** Get all products that haven't been discontinued.
+        **Example:** Get all products that have not been discontinued.
 
         .. literalinclude:: ../../examples/examples.py
-            :start-after: [START update_item]
-            :end-before: [END update_item]
+            :start-after: [START query_items]
+            :end-before: [END query_items]
             :language: python
             :dedent: 0
 
-        **Example:** Parameterized query to find all families in the state of NY.
+        **Example:** Parameterized query to get all products that have been discontinued.
 
-        .. code-block:: python
-
-            items = container.query_items(
-                query='SELECT * FROM Families f WHERE f.address.state = @addressState',
-                parameters=[
-                    dict(name='@addressState', value='NY')
-                ]
-            )
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START query_items_param]
+            :end-before: [END query_items_param]
+            :language: python
+            :dedent: 0
 
         """
         items = self.client_context.QueryItems(

--- a/azure/cosmos/__init__.py
+++ b/azure/cosmos/__init__.py
@@ -50,12 +50,11 @@ class CosmosClient:
 
         **Example**: Create a new client instance.
 
-        .. code-block:: python
-
-            import os
-            ACCOUNT_KEY = os.environ['ACCOUNT_KEY']
-            ACCOUNT_URI = os.environ['ACCOUNT_URI']
-            client = CosmosClient(url=ACCOUNT_URI, key=ACCOUNT_KEY)
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START create_client]
+            :end-before: [END create_client]
+            :language: python
+            :dedent: 0
 
         """
         self.client_context = ClientContext(
@@ -77,15 +76,13 @@ class CosmosClient:
         :returns: A :class:`Database` instance representing the new database.
         :raises `HTTPFailure`: If `fail_if_exists` is set to True and a database with the given ID already exists.
 
-        **Example**: Create a new database.
+        **Example**: Create a database in the Cosmos DB account.
 
-        .. code-block:: python
-
-            import os
-            ACCOUNT_KEY = os.environ['ACCOUNT_KEY']
-            ACCOUNT_URI = os.environ['ACCOUNT_URI']
-            client = CosmosClient(url=ACCOUNT_URI, key=ACCOUNT_KEY)
-            database = client.create_database('nameofdatabase')
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START create_database]
+            :end-before: [END create_database]
+            :language: python
+            :dedent: 0
 
         """
         try:
@@ -201,23 +198,19 @@ class Database:
 
         **Example:** Create a container name 'mycontainer' with default settings:
 
-        .. code-block:: python
-
-            container = database.create_container('mycontainer')
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START create_container]
+            :end-before: [END create_container]
+            :language: python
+            :dedent: 0
 
         **Example:** Create a container named 'containerwithspecificsettings' with a custom partition key.
 
-        .. code-block:: python
-
-            container = database.create_container(
-                id='containerwithspecificsettings',
-                partition_key={
-                    "paths": [
-                    "/AccountNumber"
-                    ],
-                    "kind": "Hash"
-                }
-            )
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START create_container_with_settings]
+            :end-before: [END create_container_with_settings]
+            :language: python
+            :dedent: 0
 
         """
         definition = dict(id=id)
@@ -250,21 +243,17 @@ class Database:
         self.client_context.DeleteContainer(collection_link)
 
     def get_container(self, container: "Union[str, Container]") -> "Container":
-        """ Get the container with the ID (name) `container`.
+        """ Get the specified `Container`, or a container with specified ID (name).
 
         :param container: The ID (name) of the container, or a :class:`Container` instance.
         :raise `HTTPFailure`: Raised if the container couldn't be retrieved. This includes if the container does not exist.
 
-        .. code-block:: python
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START get_container]
+            :end-before: [END get_container]
+            :language: python
+            :dedent: 0
 
-            database = client.get_database('fabrikamdb')
-            try:
-                container = database.get_container('customers')
-            except HTTPFailure as failure:
-                if failure.status_code == 404:
-                    print('Container does not exist.')
-                else:
-                    print(f'Failed to retrieve container. Status code:{failure.status_code}')
         """
         collection_link = getattr(
             container, "collection_link", f"{self.database_link}/colls/{container}"
@@ -280,16 +269,18 @@ class Database:
     def list_containers(
         self, query: "str" = None, parameters=None
     ) -> "Iterable[Container]":
-        """ List the containers in this database.
+        """ List the containers in the database.
 
         :param query: The SQL query used for filtering the list of containers. If omitted, all containers in the database are returned.
         :param parameters: Parameters for the query. Only applicable if a query has been specified.
 
         **Example**: List all containers in a database.
 
-        .. code-block:: python
-
-            database.list_containers()
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START list_containers]
+            :end-before: [END list_containers]
+            :language: python
+            :dedent: 0
 
         """
         if query:
@@ -320,6 +311,13 @@ class Database:
         conflict_resolution_policy=None,
     ):
         """ Update the properties of the container. Property changes are persisted immediately.
+
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START set_container_properties]
+            :end-before: [END set_container_properties]
+            :language: python
+            :dedent: 0
+
         """
         container_id = getattr(container, "id", container)
         parameters = {
@@ -427,6 +425,15 @@ class Container:
 
         :param str id: ID of item to retrieve.
         :returns: :class:`Item`, if present in the container.
+
+        **Example**: Get an item from the database and update one of its properties.
+
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START update_item]
+            :end-before: [END update_item]
+            :language: python
+            :dedent: 0
+
         """
         doc_link = f"{self.collection_link}/docs/{id}"
         result = self.client_context.ReadItem(document_link=doc_link)
@@ -467,16 +474,16 @@ class Container:
         :returns: An `Iterable` containing each :class:`Item` returned by the query, if any.
 
         You can use any value for the container name in the FROM clause, but typically the container name is used.
-        In the examples below, the container name is "Families," and is aliased as "f" for more succinct referencing
+        In the examples below, the container name is "products," and is aliased as "p" for easier referencing
         in the WHERE clause.
 
-        **Example:** Find all families in the state of NY.
+        **Example:** Get all products that haven't been discontinued.
 
-        .. code-block:: python
-
-            items = container.query_items(
-                query='SELECT * FROM Families f WHERE f.address.state = "NY"'
-            )
+        .. literalinclude:: ../../examples/examples.py
+            :start-after: [START update_item]
+            :end-before: [END update_item]
+            :language: python
+            :dedent: 0
 
         **Example:** Parameterized query to find all families in the state of NY.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,6 +31,9 @@ release = ''
 
 # -- General configuration ---------------------------------------------------
 
+# Both the class’ and the __init__ method’s docstring are concatenated and inserted.
+autoclass_content = 'both'
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -91,13 +91,26 @@ item['productModel'] = 'DISCONTINUED'
 updated_item = container.upsert_item(item)
 # [END update_item]
 
-# Query the items in a container using SQL-like syntax. This query
+# Query the items in a container using SQL-like syntax. This example
 # gets all items whose product model hasn't been discontinued.
 # [START query_items]
 import json
 for item in container.query_items(query='SELECT * FROM products p WHERE p.productModel <> "DISCONTINUED"'):
     print(json.dumps(item, indent=True))
 # [END query_items]
+
+# Parameterized queries are also supported. This example
+# gets all items whose product model has been discontinued.
+# [START query_items_param]
+discontinued_items = container.query_items(
+    query='SELECT * FROM products p WHERE p.productModel = @model',
+    parameters=[
+        dict(name='@model', value='DISCONTINUED')
+    ]
+)
+for item in discontinued_items:
+    print(json.dumps(item, indent=True))
+# [END query_items_param]
 
 # Retrieve the properties of a database
 # [START get_database_properties]
@@ -117,3 +130,16 @@ database.set_container_properties(container, default_ttl=3600)
 container_props = database.get_container(container_name).properties
 print(f"New container TTL: {json.dumps(container_props['defaultTtl'])}")
 # [END set_container_properties]
+
+# Create a user in the database.
+# [START create_user]
+try:
+    database.create_user(dict(
+        id='Walter Harp'
+        ))
+except HTTPFailure as failure:
+    if failure.status_code == 409:
+        print('A user with that ID already exists.')
+    else:
+        print(f'Failed to create user. Status code:{failure.status_code}')
+# [END create_user]

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,72 +1,119 @@
-from azure.cosmos import HTTPFailure, CosmosClient, Container, Database
+# These examples are ingested by the documentation system, and are
+# displayed in the SDK reference documentation. When editing these
+# example snippets, take into consideration how this might affect
+# the readability and usability of the reference documentation.
 
 # All interaction with Cosmos DB starts with an instance of the CosmosClient
+# [START create_client]
+from azure.cosmos import HTTPFailure, CosmosClient, Container, Database
+
 import os
 url = os.environ['ACCOUNT_URI']
 key = os.environ['ACCOUNT_KEY']
 client = CosmosClient(url, key)
+# [END create_client]
 
-test_database_name = 'testDatabase'
-test_container_name = 'testContainer'
+# Create a database in the account using the CosmosClient,
+# specifying that the operation shouldn't throw an exception
+# if a database with the given ID already exists.
+# [START create_database]
+database_name = 'testDatabase'
+database = client.create_database(id=database_name, fail_if_exists=False)
+# [END create_database]
 
-# Create a database
-db = client.create_database(id=test_database_name, fail_if_exists=False)
+# Create a container, handling the exception if a container with the
+# same ID (name) already exists in the database.
+# [START create_container]
+container_name = 'products'
 try:
-    db.create_container(id=test_container_name)
+    container = database.create_container(id=container_name)
 except HTTPFailure as e:
     if e.status_code != 409:
         raise
-    db.get_container(test_container_name)
+    container = database.get_container(container_name)
+# [END create_container]
 
-# Retrieve a container by using known database and container names, then
-# insert an item:
-container = Container(client.client_context, database=test_database_name, id=test_container_name)
-container.upsert_item({
-    'id': 'something',
-    'value': 'new'
-})
+# Create a container with custom settings. This example
+# creates a container with a custom partition key.
+# [START create_container_with_settings]
+customer_container_name = 'customers'
+try:
+    customer_container = database.create_container(
+        id=customer_container_name,
+        partition_key={
+            "paths": [
+            "/AccountNumber"
+            ],
+            "kind": "Hash"
+        }
+    )
+except HTTPFailure as e:
+    if e.status_code != 409:
+        raise
+    customer_container = database.get_container(customer_container_name)
+# [END create_container_with_settings]
 
-# Retrieve a container by walking down resource hierarchy (client->databases->containers), then
-# insert an item.
-database = client.get_database(test_database_name)
-container = database.get_container(test_container_name)
-container.upsert_item({
-    'id': 'another',
-    'value': 'something'
-})
+# Retrieve a container by walking down the resource hierarchy
+# (client->database->container), handling the exception generated
+# if no container with the specified ID was found in the database.
+# [START get_container]
+database = client.get_database(database_name)
+try:
+    container = database.get_container(container_name)
+except HTTPFailure as failure:
+    if failure.status_code == 404:
+        print('Container does not exist.')
+    else:
+        print(f'Failed to retrieve container. Status code:{failure.status_code}')
+# [END get_container]
 
-# With a Container object, you can query the items within it.
-import json
-for item in container.query_items(query='SELECT * FROM root r WHERE r.id="something"'):
-    print(json.dumps(item, indent=True))
-
-# It should be (almost) free to ask the length of a query
-# if len(items) > 4711: # TODO: NYI (should use header to get this info to make it O(1))
-#    print('Big number')
+# [START list_containers]
+database = client.get_database(database_name)
+for container in database.list_containers():
+    print(f'Container ID: {container.id}')
+# [END list_containers]
 
 # Insert new items by defining a dict and calling Container.upsert_item
+# [START upsert_items]
 for i in range(1, 10):
     container.upsert_item(dict(
         id=f'item{i}',
-        firstName='David',
-        lastName='Smith'
+        productName='Widget',
+        productModel=f'Model {i}'
         )
     )
+# [END upsert_items]
 
 # Modify an existing item in the container
-item = items[0]
-item['firstName'] = 'Some Other Name'
-updated_item = container.upsert_item(item) # ISSUE: do we update the item "in place" for system properties and  headers?
+# [START update_item]
+item = container.get_item('item2')
+item['productModel'] = 'DISCONTINUED'
+updated_item = container.upsert_item(item)
+# [END update_item]
+
+# Query the items in a container using SQL-like syntax. This query
+# gets all items whose product model hasn't been discontinued.
+# [START query_items]
+import json
+for item in container.query_items(query='SELECT * FROM products p WHERE p.productModel <> "DISCONTINUED"'):
+    print(json.dumps(item, indent=True))
+# [END query_items]
 
 # Retrieve the properties of a database
+# [START get_database_properties]
 properties = database.properties
 print(json.dumps(properties, indent=True))
+# [END get_database_properties]
 
 # Modify the properties of an existing container
-# This example sets the default time to live (TTL) for items in the container to 10 seconds
-# An item in container is deleted when the TTL expires since it was last edited
-database.set_container_properties(container, default_ttl=10)
+# This example sets the default time to live (TTL) for items in the
+# container to 3600 seconds (1 hour). An item in container is deleted
+# when the TTL has elapsed since it was last edited.
+# [START set_container_properties]
+# Set the TTL on the container to 3600 seconds (one hour)
+database.set_container_properties(container, default_ttl=3600)
 
 # Display the new TTL setting for the container
-container_props = database.get_container(test_container_name).properties
-print(json.dumps(container_props['defaultTtl']))
+container_props = database.get_container(container_name).properties
+print(f"New container TTL: {json.dumps(container_props['defaultTtl'])}")
+# [END set_container_properties]


### PR DESCRIPTION
Migrating all example code snippets from hardcoded to using `literalinclude` in the Python docstrings.

Also a fairly major overhaul of the **examples.py** file to accommodate this change, we well as add a couple more examples, and changes for consistency and flow.

The **conf.py** change instructs Sphinx to generate docs on the `__init__` method so that we get param and creation info for classes.